### PR TITLE
fix: trigger Pages deploy after daily digest workflow completes

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,6 +3,9 @@ name: Deploy static site to GitHub Pages
 on:
   push:
     branches: ["main"]
+  workflow_run:
+    workflows: ["Build Arxiv Daily Digest"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -16,6 +19,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
### Motivation
- The scheduled data update workflow `Build Arxiv Daily Digest` commits site data using `GITHUB_TOKEN`, and those bot-originated pushes do not reliably trigger other workflows that listen only for `push`, so GitHub Pages was not redeploying with new data.
- The deploy workflow should only run automatically when the digest build completes successfully to avoid deploying partial or broken data.

### Description
- Added a `workflow_run` trigger to `/.github/workflows/deploy-pages.yml` to listen for completion of the `Build Arxiv Daily Digest` workflow.
- Added an `if` condition on the `deploy` job to only proceed when the event is not a `workflow_run` or when `github.event.workflow_run.conclusion == 'success'`.
- The single modified file is `/.github/workflows/deploy-pages.yml` and the change enables automatic Pages deployment after the daily digest finishes successfully.

### Testing
- Verified repository file listing with `rg --files` and confirmed presence of workflow files, which succeeded.
- Printed and reviewed `/.github/workflows/deploy-pages.yml` and `/.github/workflows/daily-digest.yml` with `sed`/`nl` to confirm the new `workflow_run` trigger and the `if` condition were added, which succeeded.
- Confirmed the modified workflow file is staged in the working tree and readable, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22006f48483289fd7338df978ea6f)