### PR TITLE
Serve static site with Node + Docker and gate Pages deploy on build completion

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,6 +3,9 @@ name: Deploy static site to GitHub Pages
 on:
   push:
     branches: ["main"]
+  workflow_run:
+    workflows: ["Build Arxiv Daily Digest"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -16,6 +19,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY . .
+
+ENV NODE_ENV=production
+ENV PORT=10000
+
+EXPOSE 10000
+
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ python -m http.server 8000
 
 打开 <http://localhost:8000>。
 
+如果你希望用 Node 启动静态服务（与 Render Docker 部署一致）：
+
+```bash
+node server.js
+```
+
+默认监听 `3000`，也可以通过 `PORT` 环境变量覆盖。
+
 ## GitHub Pages 发布流程（仓库名：`ainewspaper`）
 
 1. 在 GitHub 创建公开仓库 `ainewspaper`。

--- a/server.js
+++ b/server.js
@@ -1,0 +1,65 @@
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+
+const PORT = process.env.PORT || 3000;
+const HOST = "0.0.0.0";
+const ROOT = __dirname;
+
+const MIME_TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".xml": "application/xml; charset=utf-8",
+  ".txt": "text/plain; charset=utf-8",
+  ".webp": "image/webp",
+};
+
+function resolvePath(urlPath) {
+  const decoded = decodeURIComponent(urlPath.split("?")[0]);
+  const normalized = path.normalize(decoded).replace(/^(\.\.[/\\])+/, "");
+  let filePath = path.join(ROOT, normalized);
+  if (normalized === "/" || normalized === ".") {
+    filePath = path.join(ROOT, "index.html");
+  }
+  return filePath;
+}
+
+const server = http.createServer((req, res) => {
+  const filePath = resolvePath(req.url || "/");
+
+  fs.stat(filePath, (statErr, stats) => {
+    if (statErr) {
+      res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Not Found");
+      return;
+    }
+
+    const targetPath = stats.isDirectory()
+      ? path.join(filePath, "index.html")
+      : filePath;
+    const ext = path.extname(targetPath).toLowerCase();
+    const contentType = MIME_TYPES[ext] || "application/octet-stream";
+
+    fs.readFile(targetPath, (readErr, data) => {
+      if (readErr) {
+        res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end("Internal Server Error");
+        return;
+      }
+      res.writeHead(200, { "Content-Type": contentType });
+      res.end(data);
+    });
+  });
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`Static site is running at http://${HOST}:${PORT}`);
+});


### PR DESCRIPTION
### Motivation

- Provide a lightweight Node-based static server and a Docker image to run the generated static site locally or on container platforms.  
- Ensure GitHub Pages deployment runs after the production data build and only when that build succeeds.

### Description

- Added a simple Node static server in `server.js` that serves files with common MIME types and falls back to `index.html` for directory/root requests.  
- Added a `Dockerfile` based on `node:20-alpine` that copies the repo, sets `NODE_ENV=production`, exposes port `10000`, and runs `node server.js`.  
- Updated `README.md` to document starting the server with `node server.js` and using the `PORT` environment variable (server defaults to `3000` if `PORT` is not set).  
- Updated `.github/workflows/deploy-pages.yml` to trigger on the completion of the `Build Arxiv Daily Digest` workflow and added a conditional (`if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'`) so deployment only proceeds when the build workflow succeeded.

### Testing

- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22006f48483289fd7338df978ea6f)